### PR TITLE
add the ability to execute more commands in the unzip method

### DIFF
--- a/src/wonkavision.js
+++ b/src/wonkavision.js
@@ -126,14 +126,20 @@ yargs
           type: 'string',
           alias: 'n',
           default: 'deploy.zip'
+        })
+        .option('extra-command', {
+          describe: 'extra command to send to the unzip',
+          type: 'string'
         });
     },
     async argv => {
       console.log(`${chalk.yellow('decompressing')}`);
 
       dotenv.config();
-
-      const command = `cd ${argv.dest}; unzip -oq ${argv.name}; rm ${argv.name}`;
+      let command = `cd ${argv.dest}; unzip -oq ${argv.name}; rm ${argv.name}`;
+      if (argv.extraCommand) {
+        command += ';' + argv.extraCommand;
+      }
       const connection = createConnection();
       if (!connection) {
         return;


### PR DESCRIPTION
for dotnet apps i ship an app_offline.htm and the deploy.zip which takes the app offline.

this new settings allows me to delete the app_offline file after unzipping the application to let the application restart.