### PR TITLE
allow clean to reach outside of pwd

### DIFF
--- a/src/wonkavision.js
+++ b/src/wonkavision.js
@@ -32,7 +32,7 @@ yargs
 
       const folderDelete = ora('removing files').start();
       if (!argv.dryRun) {
-        const deletedPaths = await del(argv.artifacts);
+        const deletedPaths = await del(argv.artifacts, {force: true});
 
         folderDelete.succeed(`removed ${chalk.red(deletedPaths.length)} items`);
       } else {


### PR DESCRIPTION
the del package only allows you to delete files from within your pwd for safety reasons. In dotnet applications where the package.json file is nested within the project, I need to reach outside of the folder to clean other dotnet assets.

If we decide that force should not be always on, I am open to an option or something.