### PR TITLE
Allow clean of multiple items

### DIFF
--- a/src/wonkavision.js
+++ b/src/wonkavision.js
@@ -13,7 +13,7 @@ const yargs = require('yargs');
 
 yargs
   .command(
-    'clean [artifacts]',
+    'clean [artifacts..]',
     'clean build artifacts',
     yargs => {
       yargs.positional('artifacts', {


### PR DESCRIPTION
the syntax was only allowing one item to be parsed from the args. Adding the `..` accepts the entire array of items to be cleaned.