### PR TITLE
fix dotnet dll execution issues

### DIFF
--- a/src/wonkavision.js
+++ b/src/wonkavision.js
@@ -94,7 +94,10 @@ yargs
       if (!argv.dryRun) {
         paths.forEach(filePath => {
           let parent = filePath.slice(baseDir.length + 1);
-          zipFile.addFile(filePath, parent);
+          zipFile.addFile(filePath, parent, {
+            mtime: new Date(),
+            mode: 040755,
+          });
         });
 
         zipFile.outputStream


### PR DESCRIPTION
dotnet dlls need execute permission (755) and the zipping was only adding read write (644).

Updating the date makes the files on the server match the deployment time instead of the original file changed date. I'm not 100% convinced this needs to be set or not but it is sort of nice to know when the deployment happened based on the file dates. ¯\_(ツ)_/¯ i'll let you choose in the review.